### PR TITLE
style: Update primary color to 100% in globals.css

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,7 +10,7 @@
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
+    --primary: 0 0% 100%;
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;


### PR DESCRIPTION
When you're using light mode in the operating system, the text blends in with the background.

![Scherm­afbeelding 2024-05-11 om 15 12 47](https://github.com/robertarnorsson/gzwmap/assets/23448484/2b810f3d-c3da-4317-9972-4d2552b5913c)
![Scherm­afbeelding 2024-05-11 om 15 12 37](https://github.com/robertarnorsson/gzwmap/assets/23448484/7d5d9531-3733-42e2-a55c-1efc132e69f7)
