### PR TITLE
Update `zoomSnap` value to 1

### DIFF
--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -25,7 +25,7 @@ export default function Map() {
       maxBounds={maxBounds}
       maxBoundsViscosity={10}
       zoom={12}
-      zoomSnap={0.1}
+      zoomSnap={1}
       zoomDelta={1}
       wheelDebounceTime={100}
       minZoom={12}


### PR DESCRIPTION
When I opened the map for the first time, it was tough to zoom in and find missions. I had to scroll many times to zoom in a little more.